### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Still very much WIP and lots to come!
 
 Feel free to contribute!
 
-##Style
+## Style
 
 - Android version names are in the format `<CodeNameLetter>-<Version>-<API>` i.e. `M-6-23`
 
-##Tools
+## Tools
 
 - Nav helper [OctoTree](https://chrome.google.com/webstore/detail/octotree/bkhaagjahfmjljalopjnoealnfndnagc)

--- a/boot/bootloader.md
+++ b/boot/bootloader.md
@@ -1,17 +1,17 @@
-##Unlocking
+## Unlocking
 
 Unlock via `fastboot` for devices that allow it. See [Unlocking the bootloader](https://source.android.com/source/running.html#unlocking-the-bootloader).
 
 > In	some	cases,	like	most	devices	built	for	use	on	the	Verizon	network,	the	ability	for	a	user	to	
 unlock	the	bootloader	is	blocked	entirely.	(from [SamDunk][SamDunk])
 
-##Security implications of unlocking
+## Security implications of unlocking
 
 [Security risks of unlocking](http://android.stackexchange.com/questions/36830/whats-the-security-implication-of-having-an-unlocked-boot-loader).
 
 Check out the `Verified Boot` section of this guide as it talks about unlocked bootloaders disabling verified boot in 7.0, which means its even more important in some cases that we know the state of it.
 
-##Checking bootloader lock status
+## Checking bootloader lock status
 
 _EDIT: 20/10/16_ SafetyNet [now seems to check bootloader status](https://www.reddit.com/r/android/comments/587ss9/_/)! 
 

--- a/changes/L_5_21.md
+++ b/changes/L_5_21.md
@@ -1,4 +1,4 @@
-#Security Change Summary for L
+# Security Change Summary for L
 
 - TrustAgents, which allows for more flexible lockscreen mechanisms provided by an application on the device (Google’s Smart Lock was built Android Security Patch Level on this technology).
 - [TLS/SSL Default Configuration Changes](http://developer.android.com/about/versions/android-5.0-changes.html#ssl)

--- a/changes/M_6_23.md
+++ b/changes/M_6_23.md
@@ -1,6 +1,6 @@
-#Security Change Summary for M-6-23
+# Security Change Summary for M-6-23
 
-##API changes
+## API changes
 
 - Runtime Permissions
   - Updated app permissions enable you to manage the data they share with specific apps with more granularity and precision.
@@ -15,7 +15,7 @@
   - Indicates whether the app intends to use cleartext network traffic, such as cleartext HTTP. The default value is "true".
 - Hardware Identifier access [removed](https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-hardware-id) (MAC) 
 
-##Under the hood changes
+## Under the hood changes
 
 - Lockscreen verification
   - With Android 6.0, Lockscreen verification now occurs in the Trusted Execution Environment (TEE) for devices that support a TEE (such as the majority of new devices that launched with Android 6.0). This provides brute force protection with exponentially increasing delays on verification of the user’s lockscreen challenge.
@@ -32,7 +32,7 @@
 - `KeyStore`
   - Keys which do not require encryption at rest will no longer be deleted when secure lock screen is disabled or reset (for example, by the user or a Device Administrator). Keys which require encryption at rest will be deleted during these events.
 
-##Sources
+## Sources
 
 More info can be found in the below
 

--- a/changes/N-7-24.md
+++ b/changes/N-7-24.md
@@ -1,4 +1,4 @@
-#Sec Change Summary for N Preview
+# Sec Change Summary for N Preview
 
 ## Key Attestation
 
@@ -9,7 +9,7 @@ supplied key
 
 [from](http://developer.android.com/preview/api-overview.html#key_attestation) 
 
-##Network Security Config
+## Network Security Config
 
 > In Android N, apps can customize the behavior of their secure (HTTPS, TLS) connections safely, without any code modification, by using the declarative Network Security Config instead of using the conventional error-prone programmatic APIs (e.g. X509TrustManager)
   - Custom trust anchors.
@@ -68,7 +68,7 @@ This has now been clarified with [Security "Crypto" provider deprecated in Andro
 
 From [Android 7.0 Compatibility Definition](http://source.android.com/compatibility/7.0/android-7.0-cdd.html#9_11_keys_and_credentials)
 
-##Other
+## Other
 
 - [`seccomp`](https://en.wikipedia.org/wiki/Seccomp) api now available natively 
   - See [IO16 talk](https://youtu.be/XZzLjllizYs?list=PLWz5rJ2EKKc8jQTUYvIfqA9lMvSGQWtte&t=2622) for more.

--- a/dev_machine/config.md
+++ b/dev_machine/config.md
@@ -1,8 +1,8 @@
-#General Tips
+# General Tips
 
 - [drduh/OS-X-Security-and-Privacy-Guide](https://github.com/drduh/OS-X-Security-and-Privacy-Guide)
 
-#Java
+# Java
 
 Keep your JDK up to date as there are [many vulns](https://www.cvedetails.com/vulnerability-list/vendor_id-93/product_id-19117/Oracle-JRE.html) and it does NOT generally auto-update.
 

--- a/framework/fingerprint.md
+++ b/framework/fingerprint.md
@@ -1,8 +1,8 @@
-#Fingerprint Support
+# Fingerprint Support
 
 Added in M-6-23, AOSP now officially supports fingerprint hardware with an API also available to applications.
 
-##API
+## API
 
 - Official Examples
   - [FingerPrintDialog](http://developer.android.com/samples/FingerprintDialog/src/com.example.android.fingerprintdialog/MainActivity.html) 
@@ -25,7 +25,7 @@ Added in M-6-23, AOSP now officially supports fingerprint hardware with an API a
 - `USER_FINGERPRINT` permission needed
 	- [`normal`](http://developer.android.com/reference/android/Manifest.permission.html#USE_FINGERPRINT) level permission, therefore no need to request at runtime
 
-##`KeyStore` keys requiring auth
+## `KeyStore` keys requiring auth
 
 > User authentication authorizes a specific cryptographic operation associated with one key. In this mode, each 
 operation involving such a key must be individually authorized by the user. Currently, the only means of such authorization 
@@ -40,7 +40,7 @@ Losing Keys after new finger enrollment
 Taken from [`setUserAuthenticationRequired()`](http://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.Builder.html#setUserAuthenticationRequired(boolean)). More info about Key creation can be found in [keystore.md](/api/keystore.md).
 
 
-##AOSP CTS Requirements
+## AOSP CTS Requirements
 
 To have google apps & services OEM devices must pass the CTS. 
 [M-6-23 Compatability Doc](http://static.googleusercontent.com/media/source.android.com/en//compatibility/android-cdd.pdf)
@@ -49,7 +49,7 @@ To have google apps & services OEM devices must pass the CTS.
 
 > MUST have a false acceptance rate not higher than 0.002%.
 
-##3rd party OEM APIs
+## 3rd party OEM APIs
 
 Some OEMs have introduced their own fingerprint API/hardware outside of the CTS running Android versions pre M-6-23. These include:
 
@@ -62,7 +62,7 @@ Its unknown if each OEM will maintain their own API as well as AOSPs when runnin
 
 Some 3rd party (non-CTS?) implementations have been [shown to be vulnerable](http://www.engadget.com/2015/08/05/android-fingerprint-readers-may-be-easier-to-hack-than-touch-id/) however. 
 
-##Risk of using Biometric?
+## Risk of using Biometric?
 
 There are a few articles saying using biometric is very risky as if you lose your fingerprint data you cant change your 
 fingers. Using fingerprint on Android will never allow access to any print data directly and can only be directly be 
@@ -72,13 +72,13 @@ _and_ someone clones your fingerprint then this security measure is bypassed. In
 
 Official link [Fingerprint security on Nexus devices](https://support.google.com/nexus/answer/6300638?hl=en-GB)
 
-##Links
+## Links
 
 - [Official] [New in Android Samples: Authenticating to remote servers using the Fingerprint API](http://android-developers.blogspot.co.uk/2015/10/new-in-android-samples-authenticating.html?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed:+blogspot/hsDu+(Android+Developers+Blog))
   - Talks about `.setUserAuthenticationRequired(true)` 
 - [Android: Fingerprint Authentication Thoughts](https://medium.com/@manuelvicnt/android-fingerprint-authentication-f8c7c76c50f8#.htn7xmypk)
 
-##Libs 
+## Libs 
 
 - [square/Whorlwind](https://github.com/square/whorlwind)
   - A reactive wrapper around Android's fingerprint API that handles encrypting/decrypting sensitive data using a fingerprint.

--- a/framework/safetynet.md
+++ b/framework/safetynet.md
@@ -4,7 +4,7 @@
   - "The service provides an API your app can use to analyze the device where it is installed. The API uses software and hardware information on the device where your app is installed to create a profile of that device. The service then attempts to match it to a list of device models that have passed Android compatibility testing. This check can help you decide if the device is configured in a way that is consistent with the Android platform specifications and has the capabilities to run your app."
 - [xda-developers.com] [Google Security Engineer Explains Issues With Root and Android Pay in the XDA Forums](http://www.xda-developers.com/google-security-engineer-explains-issues-with-root-and-android-pay-in-the-xda-forums/) 
 
-##What does it look for
+## What does it look for
 
 - Bootloader lock status [(reddit)](https://www.reddit.com/r/android/comments/587ss9/_/)
 - And more (see above links)

--- a/links/lang_sec_links.md
+++ b/links/lang_sec_links.md
@@ -1,4 +1,4 @@
-#Lang level sec links
+# Lang level sec links
 
 - [OWASP - Java](https://www.owasp.org/index.php/Category:Java#tab=Related_3rd_Party_Projects)
 - [Securing Java](http://www.securingjava.com/toc.html)

--- a/links/web_sec_links.md
+++ b/links/web_sec_links.md
@@ -1,4 +1,4 @@
-#Web Dev Security 
+# Web Dev Security 
 
 - [FallibleInc/security-guide-for-developers](https://github.com/FallibleInc/security-guide-for-developers)
 - [The definitive guide to form-based website authentication](http://stackoverflow.com/questions/549/the-definitive-guide-to-form-based-website-authentication)

--- a/network/https.md
+++ b/network/https.md
@@ -1,21 +1,21 @@
-#Https CAs
+# Https CAs
 
 > To provide a more consistent and more secure experience across the Android ecosystem, beginning with Android Nougat, compatible devices trust only the standardized system CAs maintained in AOSP. 
 
 From [android-developers.blogspot] [Changes to Trusted Certificate Authorities in Android Nougat](http://android-developers.blogspot.co.uk/2016/07/changes-to-trusted-certificate.html)
 
-###Dev/DEBUG settings
+### Dev/DEBUG settings
 
 Starting in N can add custom trust anchors via xml which are used only for debug builds. Removes the vuln of accidentially leaving debug code in production. 
 
 - [IO link](https://youtu.be/XZzLjllizYs?t=1405)
 - [developer.android.com] [Network Security Configuration] (http://developer.android.com/preview/features/security-config.html).
 
-###Chain info tools
+### Chain info tools
 
 - https://langui.sh/2009/03/14/checking-a-remote-certificate-chain-with-openssl/
 
-#Enforcing Https
+# Enforcing Https
 
 From [Protecting against unintentional regressions to cleartext traffic in your Android apps](https://security.googleblog.com/2016/04/protecting-against-unintentional.html)
 

--- a/network/tls_cert_pinning.md
+++ b/network/tls_cert_pinning.md
@@ -1,4 +1,4 @@
-#TLS Cert Pinning
+# TLS Cert Pinning
 
 There are various approaches to cert pinning on android. What they all have in common is that they validate the cert chain in use by looking for compile time known certs. Below is a TLDR of a simple approach as spoken about in the below links.
 
@@ -7,14 +7,14 @@ There are various approaches to cert pinning on android. What they all have in c
 - "...developers should not check pins against the list of certificates sent by the server. Instead, pins should be checked against the new, 'clean' chain that is created during SSL validation.". See Blog Posts below for more info, **lots of pinning implementations in the wild are broken**!
 - Easiest by far is to use Okhttp's `CertificatePinner` which accounts for ["cleaning the chain" (3.2.0)](https://github.com/square/okhttp/blob/parent-3.2.0/okhttp/src/main/java/okhttp3/CertificatePinner.java#L149). See [here](https://github.com/square/okhttp/wiki/HTTPS) for an example.
 
-#Changes in Nougat
+# Changes in Nougat
 
 Can pin via xml as shown 
 
 - [developer.android.com] [Network Security Configuration] (http://developer.android.com/preview/features/security-config.html#CertificatePinning).
 - [android-developers.blogspot] [Changes to Trusted Certificate Authorities in Android Nougat](http://android-developers.blogspot.co.uk/2016/07/changes-to-trusted-certificate.html) for more. 
 
-#Links
+# Links
 
 - Blog posts
   - [Paypal Engineering - Key Pinning in Mobile Applications](https://www.paypal-engineering.com/2015/10/14/key-pinning-in-mobile-applications/)
@@ -36,6 +36,6 @@ Can pin via xml as shown
   - [iSECPartners/android-ssl-bypass](https://github.com/iSECPartners/android-ssl-bypass)
   - [TrustKit-Android](https://github.com/datatheorem/TrustKit-Android)
 
-#Random Notes
+# Random Notes
 
 - When creating a `TrustManagerFactory` pass in null to get system `TrustManager`. Can pin while extending system TrustManager. 

--- a/patches/monthly.md
+++ b/patches/monthly.md
@@ -1,4 +1,4 @@
-#Monthly Official Security Patches
+# Monthly Official Security Patches
 
 - [android.os.build.VERSION.SECURITY_PATCH](https://developer.android.com/reference/android/os/Build.VERSION.html#SECURITY_PATCH)
   - Available since M-6-23

--- a/providers/alt_security_libs.md
+++ b/providers/alt_security_libs.md
@@ -1,4 +1,4 @@
-#Alt Security Libs
+# Alt Security Libs
 
 The below are general purpose security libs which supply a subset of similar functionality to the Java providers
 

--- a/providers/platform_security_providers.md
+++ b/providers/platform_security_providers.md
@@ -1,8 +1,8 @@
-#Platform Security Providers
+# Platform Security Providers
 
 Security functionality on Android is provided by various open src libs which vary depending on the OS version. There are native libs and java libs with JCE interfaces which coexist. 
 
-##Quick Overview to terms
+## Quick Overview to terms
 
 The crypto side of java has a few abbreviations associated with it, here are the most common ones:
 
@@ -19,9 +19,9 @@ The crypto side of java has a few abbreviations associated with it, here are the
 
 Guide to terms like JCE & JSSE can be found [here](http://www.oracle.com/technetwork/java/javase/tech/index-jsp-136007.html).
 
-##Native Implementations
+## Native Implementations
 
-####OpenSSL
+#### OpenSSL
 
 - Used since the beginning?
 - OpenSSL version used - look in AOSP [openSSL version file](https://github.com/android/platform_external_openssl/blob/jb-release/openssl.version) for each platform tag 
@@ -31,7 +31,7 @@ Guide to terms like JCE & JSSE can be found [here](http://www.oracle.com/technet
   - M-6 superceeded by BoringSSL 
 - Backs `SecureRandom` since [4.2](http://android-developers.blogspot.co.uk/2013/02/using-cryptography-to-store-credentials.html)
 	
-####BoringSSL
+#### BoringSSL
 
 - Android's [BoringSSL repo](https://android.googlesource.com/platform/external/boringssl/) 
 - Upstream [repo](https://boringssl.googlesource.com/boringssl/)	
@@ -41,14 +41,14 @@ Guide to terms like JCE & JSSE can be found [here](http://www.oracle.com/technet
   - Seems to pull in upstream forks patches and align to newer interfaces (1.1)
 - Transition starting in 6.0
 
-##Java JCE Providers
+## Java JCE Providers
 
-####Apache Harmonys Crypto Provider
+#### Apache Harmonys Crypto Provider
 		
 - Old and being phased out
 - Limited JCE functionality
 
-####AndroidOpenSSL
+#### AndroidOpenSSL
 
 - Introduced in 4 (SSL function only)
 - Highest priority since 4.4
@@ -71,7 +71,7 @@ Guide to terms like JCE & JSSE can be found [here](http://www.oracle.com/technet
   - This calls through a loaded `.so` lib (not included in AOSP or BoringSSL repos afaik) to [rsa.c](https://boringssl.googlesource.com/boringssl/+/master/crypto/rsa/rsa.c#222). This internally calls through to the loaded `struct RSA` (`rsa->meth->decrypt`) and will perform the op based upon the structs config. 
 - Was part of `libcore` until 4.4 
 
-####BouncyCastle
+#### BouncyCastle
 
 - Android used an old version of BC ("[crippled]")
 - Was the default security Java Security API provider
@@ -79,20 +79,20 @@ Guide to terms like JCE & JSSE can be found [here](http://www.oracle.com/technet
 - Offered full JCE functionality
 - Unsure how much (if any) functionality delegated to native (i.e. [Open|Boring]Ssl) implementation. Should look at the CSPRNG...
 
-####SpongyCastle
+#### SpongyCastle
 
 - Many people import this so can use latest BC, pretty much a jarjarlinks rename so no namespace clashes with BC. 
 - If going to use best not to make default but still set staically so can use with direct sepcifier throughout app
 
-####Crypto
+#### Crypto
 
 - Small (buggy) provider mostly offering SHA1 based operations (plus DSA on older platform versions). Reduced to SHA1PRNG and then removed completely in N.
 - [Security "Crypto" provider deprecated in Android N](http://android-developers.blogspot.co.uk/2016/06/security-crypto-provider-deprecated-in.html?utm_source=androiddevdigest)
 
-##Updating platform Provider from your app
+## Updating platform Provider from your app
 
 See [Updating Your Security Provider to Protect Against SSL Exploits](http://developer.android.com/training/articles/security-gms-provider.html). Not clear if updates `BoringSSL` or just the Java `AndroidOpenSSL` SPI (or both). 
 
-##What algorithms do the providers supply?
+## What algorithms do the providers supply?
 
 - [What crypto algorithms does Android support?](http://stackoverflow.com/questions/7560974/what-crypto-algorithms-does-android-support)

--- a/root/links.md
+++ b/root/links.md
@@ -1,4 +1,4 @@
-#Root Links
+# Root Links
 
 - [Root def](http://www.linfo.org/root.html)
 - [How-To SU](http://su.chainfire.eu/)

--- a/surveillance/general_surveillance.md
+++ b/surveillance/general_surveillance.md
@@ -1,20 +1,20 @@
-#General Surveillance
+# General Surveillance
 
 Surveillance of an individual via their mobile phone is something which is moving more and more into public conciousness, especially since the [Snowdon leaks](https://en.wikipedia.org/wiki/Global_surveillance_disclosures_(2013%E2%80%93present)) of 2013.
 
 This is spoken about in the Bruce Schneier book [Data and Goliath](https://www.schneier.com/books/data_and_goliath/) and is pretty scary reading. I thought of surveillance via mobile as an active attack on the device, but the truth is its a lot more subtle and powerful than that, and really, if you carry a mobile device thats sometimes powered on (even just the once), your vulnerable to this stuff. 
 
-##Background
+## Background
 
 - [The Machines That Betrayed Their Masters by Glenn Wilkinson](https://www.youtube.com/watch?v=GvrB6S_O0BE) 
   - An enlightening talk from Black Hat London 2015.
 
-##How to retain privacy
+## How to retain privacy
   
 - [Defcon 18 - Changing threats to privacy Moxie Marlinspike](https://www.youtube.com/watch?v=dBtmzY5gcO8)
 - [Being privacy-aware in 2016](https://news.ycombinator.com/item?id=11845689)
 
-##Why is privacy important
+## Why is privacy important
 
 - [Why privacy is important, and having "nothing to hide" is irrelevant](https://robindoherty.com/2016/01/06/nothing-to-hide.html) 
   - Great read about why we should care about this stuff, even if we are doing nothing "wrong". 

--- a/tools/general_tool_links.md
+++ b/tools/general_tool_links.md
@@ -123,7 +123,7 @@ _Below are taken from [FileSystem Monitor Tool For iOS and Android](https://www.
   - Attempts exploits on device 
 - [NowSecure Android VTS](https://github.com/AndroidVTS/android-vts)
 
-#OS Bundles
+# OS Bundles
 
 - [Kali Linux](https://www.kali.org/)
   - Kali Linux is a Debian-based Linux distribution aimed at advanced Penetration Testing and Security Auditing. Kali contains several hundred tools aimed at various information security tasks, such as  Penetration Testing, Forensics and Reverse Engineering. 

--- a/work/android_for_work.md
+++ b/work/android_for_work.md
@@ -1,8 +1,8 @@
-#Android For Work
+# Android For Work
 
 [Official Site](https://www.android.com/work/)
 
-##OS changes
+## OS changes
 
 - N
   - Work Mode


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
